### PR TITLE
Add "Unblank lock screen" extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Installed extensions:
 - [Quick Settings Audio Devices Hider](https://extensions.gnome.org/extension/5964/quick-settings-audio-devices-hider/) (disabled by default)
 - [Remove World Clocks](https://extensions.gnome.org/extension/6973/remove-world-clocks/) (disabled by default)
 - [Sleep Through Notifications](https://gitlab.gnome.org/rhendric/sleep-through-notifications) (disabled by default, useful for setups where screen wake on new notifications is annoying, while retaining notifications functionality)
+- [Unblank lock screen](https://github.com/sunwxg/gnome-shell-extension-unblank) (disabled by default, useful if you don't want the behavior of locking the screen to also turn off your screen)
 
 Installed flatpaks:
 - [Boxes](https://apps.gnome.org/en/Boxes/)

--- a/recipes/module-recipes/gnome-extensions.yml
+++ b/recipes/module-recipes/gnome-extensions.yml
@@ -12,3 +12,4 @@ install:
   - Quick Settings Audio Devices Hider
   - Remove World Clocks
   - Sleep Through Notifications
+  - Unblank lock screen


### PR DESCRIPTION
Testing it in a PR, because extension page says that it's automatically enabled when extension is installed & that it needs to be manually disabled.

I want it disabled by default, so I'm testing it here.

That note is probably only valid if extension is installed through DBUS (on booted system), while file-based method of gnome-extensions shouldn't modify anything regarding extension state.

But better to test it before landing.