### PR TITLE
Switch from Universal Blue to Fedora Atomic base

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -51,8 +51,6 @@ jobs:
           image_name: ${{ matrix.image_name }}
           image_tag: ${{ matrix.image_tag }}
           variant: 'Kinoite'
-          enrollment_password: 'universalblue'
-          secure_boot_key_url: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
           iso_name: ${{ matrix.image_name }}_${{ env.TIMESTAMP }}.iso
           enable_cache_dnf: "false"
           enable_cache_skopeo: "false"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Replaced packages (RPMs):
 Replaced packages (RPMs) with flatpaks:
 - [LibreWolf](https://flathub.org/apps/io.gitlab.librewolf-community) instead of [Firefox](https://www.mozilla.org/en-US/firefox/)  
    (it has better defaults, like Ublock Origin out-of-the-box, doesn't send telemetry & it offers easy customization to fix some LibreWolf quirks)
-- [Mission Center](https://flathub.org/apps/io.missioncenter.MissionCenter) instead of [Gnome System Monitor](https://gitlab.gnome.org/GNOME/gnome-system-monitor), [nvtop](https://github.com/Syllo/nvtop) & [htop](https://github.com/htop-dev/htop)  
+- [Mission Center](https://flathub.org/apps/io.missioncenter.MissionCenter) instead of [Gnome System Monitor](https://gitlab.gnome.org/GNOME/gnome-system-monitor)  
    (it's a much better looking task manager with more useful functionality)
 
 Installed packages (RPMs):

--- a/README.md
+++ b/README.md
@@ -48,15 +48,6 @@ Installed packages (RPMs):
 - [pandoc](https://github.com/jgm/pandoc) (CLI Document converter)
 - [totem-video-thumbnailer](https://packages.fedoraproject.org/pkgs/totem/totem-video-thumbnailer/) (installed to retain good amount of supported thumbnails, until something better comes in)
 
-Installed akmods:
-- [NCT6687D](https://github.com/Fred78290/nct6687d) (AMD B550 chipset temperature driver)
-- [OpenRazer](https://openrazer.github.io/) (for supporting Razer devices)
-- [V4L2-loopback](https://github.com/umlaeute/v4l2loopback) (for allowing you to create virtual video devices to apply some cool effects to real video devices)
-- [XOne](https://github.com/medusalix/xone) (Xbox One RF driver)
-- [XPadNeo](https://github.com/atar-axis/xpadneo) (Xbox One Bluetooth driver)
-- [XPad](https://github.com/paroj/xpad) (Xbox/Xbox 360 USB & RF driver + Xbox One USB driver - built-in into upstream kernel)
-- [Zenergy](https://github.com/BoukeHaarsma23/zenergy) (AMD Ryzen/Threadripper CPU sensor reading driver)
-
 Installed extensions:
 - [Blur my Shell](https://github.com/aunetx/blur-my-shell)
 - [Caffeine](https://github.com/eonpatapon/gnome-shell-extension-caffeine)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 ![](assets/bg.webp)
 
-My customized image, based on slightly customized [Silverblue-main](https://universal-blue.discourse.group/docs?topic=868) base image, which is derived from the amazing [Universal Blue](https://universal-blue.org/) project.  
-Thanks to Fedora for developing the original [Fedora Silverblue](https://fedoraproject.org/atomic-desktops/silverblue/) Linux distribution.
+My customized image, based on [Fedora Silverblue](https://fedoraproject.org/atomic-desktops/silverblue/).
+
+Gidro-OS was based on [Universal Blue's](https://universal-blue.org/) `silverblue-main` image in the past, but now, I just take some stuff that I need from them in a convenient recipe as a base.  
+Reasoning for that is to have more control over the Universal Blue's base, which would make it possible for me to react immediately with changes if needed, to avoid some questionable additions to the base, to make image smaller (and with it, updates faster) etc.  
+You can see my changes to the base recipe [here](https://github.com/fiftydinar/gidro-os/blob/main/recipes/base.yml).
 
 This image is created using the easy & robust [BlueBuild](https://blue-build.org/) tooling for creating & maintaining container-based Linux desktop images.  
 It is similar to making custom ROMs in the Android community, but in a much easier & more reliable way.
@@ -15,7 +18,6 @@ It is similar to making custom ROMs in the Android community, but in a much easi
 Removed packages (RPMs):
 - [Gnome classic session](https://help.gnome.org/users/gnome-help/stable/gnome-classic.html.en)
 - Gnome system extensions (some are from Fedora, some are from Gnome classic session, which are not needed)
-- [Gnome Tweaks](https://gitlab.gnome.org/GNOME/gnome-tweaks) (It's lowly maintained & It's not officially supported by Gnome)
 
 Replaced packages (RPMs):
 - [Yafti](https://github.com/ublue-os/yafti) instead of [Gnome Initial Setup](https://gitlab.gnome.org/GNOME/gnome-initial-setup) & [Gnome Tour](https://gitlab.gnome.org/GNOME/gnome-tour)  
@@ -193,24 +195,11 @@ ISO doesn't require an active internet connection during its usage.
 
 Just download the ISO & proceed with installation.
 
-If you are on UEFI system, you will notice blue MOK screen after installer, which is used for enrolling security keys.
-You will need to "Enroll key" with a password `universalblue`.
-This needs to be done even if you're not using Secure Boot.
-
-Otherwise, continue boot.
-
 ## Installation (Rebase)
 
 Please read the [Wiki](https://github.com/fiftydinar/gidro-os/wiki) before proceeding with the installation.
 
 Rebasing is only supported from Fedora Silverblue edition.
-
-You will need to enroll security key before rebase with the command below, even if you're not using Secure Boot (requires internet).
-It will prompt you for sudo user password, so type that, then type the password for secure key, which is `universalblue`:
-
-```
-wget -q https://github.com/ublue-os/akmods/raw/main/certs/public_key.der -O /tmp/akmods-ublue.der && sudo mokutil --timeout -1 && sudo mokutil --import /tmp/akmods-ublue.der && rm /tmp/akmods-ublue.der
-```
 
 To rebase an existing Silverblue installation to the latest build:
 
@@ -237,10 +226,6 @@ To rebase an existing Silverblue installation to the latest build:
   ```
   systemctl reboot
   ```
-
-- You will be prompted with blue MOK screen, which is used for enrolling security keys.
-  Choose "Enroll key" & type `universalblue` as a password. Continue boot afterwards.
-
 - Then rebase to the signed image, like so:
   ```
   rpm-ostree rebase ostree-image-signed:docker://ghcr.io/fiftydinar/gidro-os:latest

--- a/files/scripts/remove-redundant-avif-thumbnailer.sh
+++ b/files/scripts/remove-redundant-avif-thumbnailer.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# Tell build process to exit if there are any errors.
-set -euo pipefail
-
-# Remove avif thumbnailer, as heif thumbnailer already caches it
-rm "/usr/share/thumbnailers/avif.thumbnailer"

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -84,7 +84,7 @@ modules:
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
       - echo "Downloading & Installing gum"
-      - echo -e '#!/usr/bin/env bash\n\ncurl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r ".tag_name"\nDOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"\ncurl -fLs --create-dirs "${DOWNLOAD_URL}" -o /usr/bin/gum\nchmod -x /usr/bin/gum' > /tmp/install-gum.sh
+      - echo -e '#!/usr/bin/env bash\n\ncurl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r ".tag_name"\nDOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"\ncurl -fLs --create-dirs "${DOWNLOAD_URL}" -o /tmp/gum.rpm\nrpm-ostree install /tmp/gum.rpm' > /tmp/install-gum.sh
       - chmod +x /tmp/install-gum.sh
       - /tmp/install-gum.sh
       - rm /tmp/install-gum.sh

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -23,7 +23,7 @@ modules:
       - unzip -q /tmp/ublue-config/game-devices-udev/main.zip -d /tmp/ublue-config/game-devices-udev/
       - rm /tmp/ublue-config/game-devices-udev/main.zip
       - echo "Copying udev rules from Game-device-udev"
-      - cp /tmp/ublue-config/game-devices-udev/game-devices-udev-main/game-devices-udev/*.rules /usr/lib/udev/rules.d/
+      - cp /tmp/ublue-config/game-devices-udev/game-devices-udev/*.rules /usr/lib/udev/rules.d/
       - echo "Putting uinput to be loaded as a module in modules-load.d"
       - echo "uinput" > /usr/lib/modules-load.d/uinput.conf
       # Android udev rule

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -5,142 +5,142 @@ modules:
 # - android-udev-rules
 # - ublue-os-update-services
 # - ublue-os-just (stripped version: without motd tips, Ublue justfiles, non-needed brew profile.d script & Ublue distrobox+podman manifest files)
-- type: script
-  snippets:
-    # Download Universal Blue config zip
-    - echo "Downloading Universal Blue config zip file"
-    - curl -fLs --create-dirs https://github.com/ublue-os/config/archive/refs/heads/main.zip -o /tmp/ublue-config/main.zip
-    - echo "Unzipping the file"
-    - unzip -q /tmp/ublue-config/main.zip -d /tmp/ublue-config/
-    - rm /tmp/ublue-config/main.zip
-    # Universal Blue udev rules    
-    - echo "Copying udev rules from Universal Blue"
-    - cp /tmp/ublue-config/config-main/files/etc/udev/rules.d/*.rules /usr/lib/udev/rules.d/
-    # Game-device-udev rules
-    - echo "Downloading game-device-udev zip file"    
-    - curl -fLs --create-dirs https://codeberg.org/fabiscafe/game-devices-udev/archive/main.zip -o /tmp/ublue-config/game-devices-udev/main.zip
-    - echo "Unzipping the file"
-    - unzip -q /tmp/ublue-config/game-devices-udev/main.zip -d /tmp/ublue-config/game-devices-udev/
-    - rm /tmp/ublue-config/game-devices-udev/main.zip
-    - echo "Copying udev rules from Game-device-udev"
-    - cp /tmp/ublue-config/game-devices-udev/game-devices-udev-main/game-devices-udev/*.rules /usr/lib/udev/rules.d/
-    - echo "Putting uinput to be loaded as a module in modules-load.d"
-    - echo "uinput" > /usr/lib/modules-load.d/uinput.conf
-    # Android udev rule
-    - echo "Downloading Android udev rule"
-    - curl -fLs --create-dirs https://raw.githubusercontent.com/M0Rf30/android-udev-rules/refs/heads/main/51-android.rules -O /usr/lib/udev/rules.d/
-    - echo "Adding adbusers group to sysusers.d"
-    - echo "g adbusers - -" > /usr/lib/sysusers.d/android-udev.conf
-    # rpm-ostree & flatpak updaters
-    ## rpm-ostree updater
-    - echo "Copying rpm-ostree updater"
-    - mkdir -p /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/ /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/
-    - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
-    - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/override.conf
-    - echo "Enabling rpm-ostree updates in config"
-    - sed -i 's/^AutomaticUpdatePolicy=.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf
-    ## flatpak updater
-    - echo "Copying flatpak updater"
-    - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.timer /usr/lib/systemd/system/flatpak-system-update.timer
-    - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.service /usr/lib/systemd/system/flatpak-system-update.service
-    - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
-    - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
-    - echo "Enabling systemd timers for flatpak updaters"
-    - systemctl --system enable flatpak-system-update.timer
-    - systemctl --global enable flatpak-user-update.timer
-    # Add just config from Universal Blue
-    - echo "Adding just config from Universal Blue"
-    - echo "Excluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)"
-    - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
-    - mkdir -p /usr/share/ublue-os/just/
-    - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
-    - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
-    ## Include Gidro-OS justfile
-    - echo "Only including Gidro-OS justfile"
-    - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/just/justfile
-    ## Copy ujust & ugum binary
-    - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust; chmod -x /usr/bin/ujust
-    - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum; chmod -x /usr/bin/ugum
-    ## Copy ujust libraries
-    - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/
-    # Use ZSTD compression for initramfs
-    echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
-    # Remove temporary directory
-    - rm -r /tmp/ublue-config/
+  - type: script
+    snippets:
+      # Download Universal Blue config zip
+      - echo "Downloading Universal Blue config zip file"
+      - curl -fLs --create-dirs https://github.com/ublue-os/config/archive/refs/heads/main.zip -o /tmp/ublue-config/main.zip
+      - echo "Unzipping the file"
+      - unzip -q /tmp/ublue-config/main.zip -d /tmp/ublue-config/
+      - rm /tmp/ublue-config/main.zip
+      # Universal Blue udev rules    
+      - echo "Copying udev rules from Universal Blue"
+      - cp /tmp/ublue-config/config-main/files/etc/udev/rules.d/*.rules /usr/lib/udev/rules.d/
+      # Game-device-udev rules
+      - echo "Downloading game-device-udev zip file"    
+      - curl -fLs --create-dirs https://codeberg.org/fabiscafe/game-devices-udev/archive/main.zip -o /tmp/ublue-config/game-devices-udev/main.zip
+      - echo "Unzipping the file"
+      - unzip -q /tmp/ublue-config/game-devices-udev/main.zip -d /tmp/ublue-config/game-devices-udev/
+      - rm /tmp/ublue-config/game-devices-udev/main.zip
+      - echo "Copying udev rules from Game-device-udev"
+      - cp /tmp/ublue-config/game-devices-udev/game-devices-udev-main/game-devices-udev/*.rules /usr/lib/udev/rules.d/
+      - echo "Putting uinput to be loaded as a module in modules-load.d"
+      - echo "uinput" > /usr/lib/modules-load.d/uinput.conf
+      # Android udev rule
+      - echo "Downloading Android udev rule"
+      - curl -fLs --create-dirs https://raw.githubusercontent.com/M0Rf30/android-udev-rules/refs/heads/main/51-android.rules -O /usr/lib/udev/rules.d/
+      - echo "Adding adbusers group to sysusers.d"
+      - echo "g adbusers - -" > /usr/lib/sysusers.d/android-udev.conf
+      # rpm-ostree & flatpak updaters
+      ## rpm-ostree updater
+      - echo "Copying rpm-ostree updater"
+      - mkdir -p /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/ /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/
+      - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
+      - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/override.conf
+      - echo "Enabling rpm-ostree updates in config"
+      - sed -i 's/^AutomaticUpdatePolicy=.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf
+      ## flatpak updater
+      - echo "Copying flatpak updater"
+      - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.timer /usr/lib/systemd/system/flatpak-system-update.timer
+      - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.service /usr/lib/systemd/system/flatpak-system-update.service
+      - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
+      - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
+      - echo "Enabling systemd timers for flatpak updaters"
+      - systemctl --system enable flatpak-system-update.timer
+      - systemctl --global enable flatpak-user-update.timer
+      # Add just config from Universal Blue
+      - echo "Adding just config from Universal Blue"
+      - echo "Excluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)"
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
+      - mkdir -p /usr/share/ublue-os/just/
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
+      ## Include Gidro-OS justfile
+      - echo "Only including Gidro-OS justfile"
+      - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/just/justfile
+      ## Copy ujust & ugum binary
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust; chmod -x /usr/bin/ujust
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum; chmod -x /usr/bin/ugum
+      ## Copy ujust libraries
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/
+      # Use ZSTD compression for initramfs
+      echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
+      # Remove temporary directory
+      - rm -r /tmp/ublue-config/ 
 
-# Add negativo repo, modify its repo priority & replace some packages like HEIF & mesa
-# Also install gum
-# The operations above cannot be covered in rpm-ostree module, so it's used as a script
-- type: scripts
-  snippets:
-    # Install Negativo repo
-    - echo "Installing Negativo repo"
-    - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -O /etc/yum.repos.d/
-    - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
-    # Replace Fedora packages with Negativos (Mesa & HEIF)
-    - echo "Replacing Fedora packages with Negativos"
-    - rpm-ostree override replace --experimental from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
-    # Install gum
-    - echo "Downloading & Installing gum"
-    - LATEST_RELEASE=$(curl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r '.tag_name')
-    - DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"
-    - curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
+  # Add negativo repo, modify its repo priority & replace some packages like HEIF & mesa
+  # Also install gum
+  # The operations above cannot be covered in rpm-ostree module, so it's used as a script
+  - type: scripts
+    snippets:
+      # Install Negativo repo
+      - echo "Installing Negativo repo"
+      - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -O /etc/yum.repos.d/
+      - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+      # Replace Fedora packages with Negativos (Mesa & HEIF)
+      - echo "Replacing Fedora packages with Negativos"
+      - rpm-ostree override replace --experimental from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
+      # Install gum
+      - echo "Downloading & Installing gum"
+      - LATEST_RELEASE=$(curl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r '.tag_name')
+      - DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"
+      - curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
 
-- type: rpm-ostree
-  remove:
-    - fdk-aac-free
-    - ffmpeg-free
-    - libavcodec-free
-    - libavdevice-free
-    - libavfilter-free
-    - libavformat-free
-    - libavutil-free
-    - libpostproc-free
-    - libswresample-free
-    - libswscale-free
-    - default-fonts-cjk-sans
-    - google-noto-sans-cjk-vf-fonts
-  install:
-    # Font stuff
-    - google-noto-sans-balinese-fonts
-    - google-noto-sans-cjk-fonts
-    - google-noto-sans-javanese-fonts
-    - google-noto-sans-sundanese-fonts
-    # Graphic stuff
-    - intel-vaapi-driver
-    - libva-utils
-    # Audio stuff
-    - alsa-firmware
-    - pipewire-libs-extra
-    # Thumbnailing
-    - ffmpegthumbnailer
-    - ffmpeg
-    - ffmpeg-libs
-    # Codecs
-    - libfdk-aac
-    - heif-pixbuf-loader
-    # Just
-    - just
-    # Some additional udev rules
-    - openrgb-udev-rules
-    - solaar-udev
-    - oversteer-udev
-    # Yubikey stuff
-    - pam-u2f
-    - pam_yubico
-    - pamu2fcfg
-    - yubikey-manager 
-    # Gnome-specific
-    - adw-gtk3-theme
-    - gnome-epub-thumbnailer
-    - gvfs-nfs
-    # Regular packages    
-    - openssl
-    - libratbag-ratbagd
-    - zstd
-    - wireguard-tools
-# My additions to the base image, which are not present in Ublue    
-# Remove avif thumbnailer, as HEIF thumbnailer already covers it    
-- type: scripts
-  snippets:
-    - rm /usr/share/thumbnailers/avif.thumbnailer
+  - type: rpm-ostree
+    remove:
+      - fdk-aac-free
+      - ffmpeg-free
+      - libavcodec-free
+      - libavdevice-free
+      - libavfilter-free
+      - libavformat-free
+      - libavutil-free
+      - libpostproc-free
+      - libswresample-free
+      - libswscale-free
+      - default-fonts-cjk-sans
+      - google-noto-sans-cjk-vf-fonts
+    install:
+      # Font stuff
+      - google-noto-sans-balinese-fonts
+      - google-noto-sans-cjk-fonts
+      - google-noto-sans-javanese-fonts
+      - google-noto-sans-sundanese-fonts
+      # Graphic stuff
+      - intel-vaapi-driver
+      - libva-utils
+      # Audio stuff
+      - alsa-firmware
+      - pipewire-libs-extra
+      # Thumbnailing
+      - ffmpegthumbnailer
+      - ffmpeg
+      - ffmpeg-libs
+      # Codecs
+      - libfdk-aac
+      - heif-pixbuf-loader
+      # Just
+      - just
+      # Some additional udev rules
+      - openrgb-udev-rules
+      - solaar-udev
+      - oversteer-udev
+      # Yubikey stuff
+      - pam-u2f
+      - pam_yubico
+      - pamu2fcfg
+      - yubikey-manager 
+      # Gnome-specific
+      - adw-gtk3-theme
+      - gnome-epub-thumbnailer
+      - gvfs-nfs
+      # Regular packages    
+      - openssl
+      - libratbag-ratbagd
+      - zstd
+      - wireguard-tools
+  # My additions to the base image, which are not present in Ublue    
+  # Remove avif thumbnailer, as HEIF thumbnailer already covers it    
+  - type: scripts
+    snippets:
+      - rm /usr/share/thumbnailers/avif.thumbnailer

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -72,7 +72,7 @@ modules:
   # Add negativo repo, modify its repo priority & replace some packages like HEIF & mesa
   # Also install gum
   # The operations above cannot be covered in rpm-ostree module, so it's used as a script
-  - type: scripts
+  - type: script
     snippets:
       # Install Negativo repo
       - echo "Installing Negativo repo"
@@ -142,6 +142,6 @@ modules:
       - wireguard-tools
   # My additions to the base image, which are not present in Ublue    
   # Remove avif thumbnailer, as HEIF thumbnailer already covers it    
-  - type: scripts
+  - type: script
     snippets:
       - rm /usr/share/thumbnailers/avif.thumbnailer

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -1,3 +1,4 @@
+modules:
 # Covering ublue-os config here for my needs (using scripts, because grabbing Containerfile would bloat the image size + I have more control this way)
 # Added:
 # - ublue-os-udev-rules

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -54,7 +54,7 @@ modules:
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
-      - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/justfile
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
       - echo "import \"/usr/share/ublue-os/just/60-custom.just\"" >> /usr/share/ublue-os/justfile

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -84,7 +84,9 @@ modules:
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
       - echo "Downloading & Installing gum"
-      - LATEST_RELEASE=$(curl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r '.tag_name'); DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"; curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
+      - echo -e '#!/usr/bin/env bash\n\ncurl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r ".tag_name"\nDOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"\ncurl -fLs --create-dirs "${DOWNLOAD_URL}" -o /usr/bin/gum\nchmod -x /usr/bin/gum' > /tmp/install-gum.sh
+      - /tmp/install-gum.sh
+      - rm /tmp/install-gum.sh
       # Remove chsh & lchsh
       - rm /usr/bin/chsh
       - rm /usr/bin/lchsh

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -38,7 +38,7 @@ modules:
       - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
       - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/override.conf
       - echo -e "\033[90mEnabling rpm-ostree updates in config\033[0m"
-      - sed -i 's/^AutomaticUpdatePolicy=.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf
+      - sed -i '/^#*AutomaticUpdatePolicy=.*/s/.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf
       ## flatpak updater
       - echo -e "\033[90mCopying flatpak updater\033[0m"
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.timer /usr/lib/systemd/system/flatpak-system-update.timer

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -43,8 +43,8 @@ modules:
       - echo "Copying flatpak updater"
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.timer /usr/lib/systemd/system/flatpak-system-update.timer
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.service /usr/lib/systemd/system/flatpak-system-update.service
-      - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
-      - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
+      - cp /tmp/ublue-config/config-main/files/usr/lib/user/user/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
+      - cp /tmp/ublue-config/config-main/files/usr/lib/user/user/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
       - echo "Enabling systemd timers for flatpak updaters"
       - systemctl --system enable flatpak-system-update.timer
       - systemctl --global enable flatpak-user-update.timer

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -85,6 +85,7 @@ modules:
       # Install gum
       - echo "Downloading & Installing gum"
       - echo -e '#!/usr/bin/env bash\n\ncurl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r ".tag_name"\nDOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"\ncurl -fLs --create-dirs "${DOWNLOAD_URL}" -o /usr/bin/gum\nchmod -x /usr/bin/gum' > /tmp/install-gum.sh
+      - chmod +x /tmp/install-gum.sh
       - /tmp/install-gum.sh
       - rm /tmp/install-gum.sh
       # Remove chsh & lchsh

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -28,7 +28,7 @@ modules:
       - echo "uinput" > /usr/lib/modules-load.d/uinput.conf
       # Android udev rule
       - echo "Downloading Android udev rule"
-      - curl -fLs --create-dirs https://raw.githubusercontent.com/M0Rf30/android-udev-rules/refs/heads/main/51-android.rules -O /usr/lib/udev/rules.d/
+      - curl -fLs --create-dirs https://raw.githubusercontent.com/M0Rf30/android-udev-rules/refs/heads/main/51-android.rules -o /usr/lib/udev/rules.d/51-android.rules
       - echo "Adding adbusers group to sysusers.d"
       - echo "g adbusers - -" > /usr/lib/sysusers.d/android-udev.conf
       # rpm-ostree & flatpak updaters
@@ -75,7 +75,7 @@ modules:
     snippets:
       # Install Negativo repo
       - echo "Installing Negativo repo"
-      - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -O /etc/yum.repos.d/
+      - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -o /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       # Replace Fedora packages with Negativos (Mesa & HEIF)
       - echo "Replacing Fedora packages with Negativos"

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -55,7 +55,8 @@ modules:
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/justfile
-      - sed -i '/echo "\$(Urllink "https:\/\/docs\.projectbluefin\.io\/administration#community-aliases-and-workarounds" "Click here to view the Universal Blue just documentation")"/d' /usr/share/ublue-os/justfile
+      ## Don't show link for Universal Blue documentation when invoking `ujust`
+      - sed -i '/^[[:space:]]*echo "\$(Urllink/d' /usr/share/ublue-os/justfile
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
       - echo "import \"/usr/share/ublue-os/just/60-custom.just\"" >> /usr/share/ublue-os/justfile

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -55,6 +55,7 @@ modules:
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/justfile
+      - sed -i '/echo "\$(Urllink "https:\/\/docs\.projectbluefin\.io\/administration#community-aliases-and-workarounds" "Click here to view the Universal Blue just documentation")"/d' /usr/share/ublue-os/justfile
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
       - echo "import \"/usr/share/ublue-os/just/60-custom.just\"" >> /usr/share/ublue-os/justfile

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -64,7 +64,7 @@ modules:
       ## Copy ujust libraries
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/
       # Use ZSTD compression for initramfs
-      echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
+      - echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
       # Remove temporary directory
       - rm -r /tmp/ublue-config/ 
 

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -57,7 +57,7 @@ modules:
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
-      - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/justfile
+      - echo "import \"/usr/share/ublue-os/just/60-custom.just\"" >> /usr/share/ublue-os/justfile
       ## Copy ujust & ugum binary
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust
       - chmod 755 /usr/bin/ujust

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -86,11 +86,6 @@ modules:
       # Replace Fedora packages with Negativos (Mesa & HEIF)
       - echo -e "\033[90mReplacing Fedora packages with Negativos\033[0m"
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
-      # Install gum
-      - echo -e "\033[90mDownloading charm repo\033[0m"
-      - echo -e '[charm]\nname=Charm\nbaseurl=https://repo.charm.sh/yum/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.charm.sh/yum/gpg.key' > /etc/yum.repos.d/charm.repo
-      - echo -e "\033[90mInstalling gum\033[0m"
-      - rpm-ostree install gum
       # Remove chsh
       - echo -e "\033[90mRemoving chsh\033[0m"
       - rm /usr/bin/chsh
@@ -139,6 +134,7 @@ modules:
       - heif-pixbuf-loader
       # Just
       - just
+      - fzf
       # Some additional udev rules
       - openrgb-udev-rules
       - solaar-udev

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -43,8 +43,8 @@ modules:
       - echo "Copying flatpak updater"
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.timer /usr/lib/systemd/system/flatpak-system-update.timer
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.service /usr/lib/systemd/system/flatpak-system-update.service
-      - cp /tmp/ublue-config/config-main/files/usr/lib/user/user/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
-      - cp /tmp/ublue-config/config-main/files/usr/lib/user/user/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
+      - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/user/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
+      - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/user/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
       - echo "Enabling systemd timers for flatpak updaters"
       - systemctl --system enable flatpak-system-update.timer
       - systemctl --global enable flatpak-user-update.timer

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -57,7 +57,7 @@ modules:
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
-      - echo -e "\033[90mimport /usr/share/ublue-os/just/60-custom.just\033[0m" >> /usr/share/ublue-os/just/justfile
+      - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/just/justfile
       ## Copy ujust & ugum binary
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust; chmod -x /usr/bin/ujust
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum; chmod -x /usr/bin/ugum
@@ -65,7 +65,7 @@ modules:
       - mkdir -p /usr/lib/ujust/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/
       # Use ZSTD compression for initramfs
-      - echo -e "\033[90mcompress=\"zstd\"\033[0m" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
+      - echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
       # Remove temporary directory
       - rm -r /tmp/ublue-config/ 
 

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -1,0 +1,145 @@
+# Covering ublue-os config here for my needs (using scripts, because grabbing Containerfile would bloat the image size + I have more control this way)
+# Added:
+# - ublue-os-udev-rules
+# - android-udev-rules
+# - ublue-os-update-services
+# - ublue-os-just (stripped version: without motd tips, Ublue justfiles, non-needed brew profile.d script & Ublue distrobox+podman manifest files)
+- type: script
+  snippets:
+    # Download Universal Blue config zip
+    - echo "Downloading Universal Blue config zip file"
+    - curl -fLs --create-dirs https://github.com/ublue-os/config/archive/refs/heads/main.zip -o /tmp/ublue-config/main.zip
+    - echo "Unzipping the file"
+    - unzip -q /tmp/ublue-config/main.zip -d /tmp/ublue-config/
+    - rm /tmp/ublue-config/main.zip
+    # Universal Blue udev rules    
+    - echo "Copying udev rules from Universal Blue"
+    - cp /tmp/ublue-config/config-main/files/etc/udev/rules.d/*.rules /usr/lib/udev/rules.d/
+    # Game-device-udev rules
+    - echo "Downloading game-device-udev zip file"    
+    - curl -fLs --create-dirs https://codeberg.org/fabiscafe/game-devices-udev/archive/main.zip -o /tmp/ublue-config/game-devices-udev/main.zip
+    - echo "Unzipping the file"
+    - unzip -q /tmp/ublue-config/game-devices-udev/main.zip -d /tmp/ublue-config/game-devices-udev/
+    - rm /tmp/ublue-config/game-devices-udev/main.zip
+    - echo "Copying udev rules from Game-device-udev"
+    - cp /tmp/ublue-config/game-devices-udev/game-devices-udev-main/game-devices-udev/*.rules /usr/lib/udev/rules.d/
+    - echo "Putting uinput to be loaded as a module in modules-load.d"
+    - echo "uinput" > /usr/lib/modules-load.d/uinput.conf
+    # Android udev rule
+    - echo "Downloading Android udev rule"
+    - curl -fLs --create-dirs https://raw.githubusercontent.com/M0Rf30/android-udev-rules/refs/heads/main/51-android.rules -O /usr/lib/udev/rules.d/
+    - echo "Adding adbusers group to sysusers.d"
+    - echo "g adbusers - -" > /usr/lib/sysusers.d/android-udev.conf
+    # rpm-ostree & flatpak updaters
+    ## rpm-ostree updater
+    - echo "Copying rpm-ostree updater"
+    - mkdir -p /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/ /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/
+    - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
+    - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/override.conf
+    - echo "Enabling rpm-ostree updates in config"
+    - sed -i 's/^AutomaticUpdatePolicy=.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf
+    ## flatpak updater
+    - echo "Copying flatpak updater"
+    - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.timer /usr/lib/systemd/system/flatpak-system-update.timer
+    - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.service /usr/lib/systemd/system/flatpak-system-update.service
+    - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
+    - cp /tmp/ublue-config/config-main/files/usr/lib/user/system/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
+    - echo "Enabling systemd timers for flatpak updaters"
+    - systemctl --system enable flatpak-system-update.timer
+    - systemctl --global enable flatpak-user-update.timer
+    # Add just config from Universal Blue
+    - echo "Adding just config from Universal Blue"
+    - echo "Excluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)"
+    - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
+    - mkdir -p /usr/share/ublue-os/just/
+    - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
+    - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
+    ## Include Gidro-OS justfile
+    - echo "Only including Gidro-OS justfile"
+    - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/just/justfile
+    ## Copy ujust & ugum binary
+    - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust; chmod -x /usr/bin/ujust
+    - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum; chmod -x /usr/bin/ugum
+    ## Copy ujust libraries
+    - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/
+    # Use ZSTD compression for initramfs
+    echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
+    # Remove temporary directory
+    - rm -r /tmp/ublue-config/
+
+# Add negativo repo, modify its repo priority & replace some packages like HEIF & mesa
+# Also install gum
+# The operations above cannot be covered in rpm-ostree module, so it's used as a script
+- type: scripts
+  snippets:
+    # Install Negativo repo
+    - echo "Installing Negativo repo"
+    - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -O /etc/yum.repos.d/
+    - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+    # Replace Fedora packages with Negativos (Mesa & HEIF)
+    - echo "Replacing Fedora packages with Negativos"
+    - rpm-ostree override replace --experimental from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
+    # Install gum
+    - echo "Downloading & Installing gum"
+    - LATEST_RELEASE=$(curl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r '.tag_name')
+    - DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"
+    - curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
+
+- type: rpm-ostree
+  remove:
+    - fdk-aac-free
+    - ffmpeg-free
+    - libavcodec-free
+    - libavdevice-free
+    - libavfilter-free
+    - libavformat-free
+    - libavutil-free
+    - libpostproc-free
+    - libswresample-free
+    - libswscale-free
+    - default-fonts-cjk-sans
+    - google-noto-sans-cjk-vf-fonts
+  install:
+    # Font stuff
+    - google-noto-sans-balinese-fonts
+    - google-noto-sans-cjk-fonts
+    - google-noto-sans-javanese-fonts
+    - google-noto-sans-sundanese-fonts
+    # Graphic stuff
+    - intel-vaapi-driver
+    - libva-utils
+    # Audio stuff
+    - alsa-firmware
+    - pipewire-libs-extra
+    # Thumbnailing
+    - ffmpegthumbnailer
+    - ffmpeg
+    - ffmpeg-libs
+    # Codecs
+    - libfdk-aac
+    - heif-pixbuf-loader
+    # Just
+    - just
+    # Some additional udev rules
+    - openrgb-udev-rules
+    - solaar-udev
+    - oversteer-udev
+    # Yubikey stuff
+    - pam-u2f
+    - pam_yubico
+    - pamu2fcfg
+    - yubikey-manager 
+    # Gnome-specific
+    - adw-gtk3-theme
+    - gnome-epub-thumbnailer
+    - gvfs-nfs
+    # Regular packages    
+    - openssl
+    - libratbag-ratbagd
+    - zstd
+    - wireguard-tools
+# My additions to the base image, which are not present in Ublue    
+# Remove avif thumbnailer, as HEIF thumbnailer already covers it    
+- type: scripts
+  snippets:
+    - rm /usr/share/thumbnailers/avif.thumbnailer

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -83,11 +83,9 @@ modules:
       - echo "Replacing Fedora packages with Negativos"
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
-      - echo "Downloading & Installing gum"
-      - echo -e '#!/usr/bin/env bash\n\ncurl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r ".tag_name"\nDOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"\nrpm-ostree install "${DOWNLOAD_URL}"' > /tmp/install-gum.sh
-      - chmod +x /tmp/install-gum.sh
-      - /tmp/install-gum.sh
-      - rm /tmp/install-gum.sh
+      - echo "Downloading repo & Installing gum"
+      - echo -e '[charm]\nname=Charm\nbaseurl=https://repo.charm.sh/yum/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.charm.sh/yum/gpg.key' > /etc/yum.repos.d/charm.repo
+      - rpm-ostree install gum
       # Remove chsh & lchsh
       - rm /usr/bin/chsh
       - rm /usr/bin/lchsh

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -76,7 +76,7 @@ modules:
   - type: script
     snippets:
       # Install Negativo repo
-      - echo "Installing Negativo repo"
+      - echo -e "\e[90mInstalling Negativo repo\e[0m"
       - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -o /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       # Replace Fedora packages with Negativos (Mesa & HEIF)
@@ -86,9 +86,8 @@ modules:
       - echo "Downloading repo & Installing gum"
       - echo -e '[charm]\nname=Charm\nbaseurl=https://repo.charm.sh/yum/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.charm.sh/yum/gpg.key' > /etc/yum.repos.d/charm.repo
       - rpm-ostree install gum
-      # Remove chsh & lchsh
+      # Remove chsh
       - rm /usr/bin/chsh
-      - rm /usr/bin/lchsh
 
   - type: rpm-ostree
     remove:

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -76,19 +76,30 @@ modules:
   - type: script
     snippets:
       # Install Negativo repo
-      - echo -e "\e[90mInstalling Negativo repo\e[0m"
+      - echo "Installing Negativo repo"
       - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -o /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       # Replace Fedora packages with Negativos (Mesa & HEIF)
       - echo "Replacing Fedora packages with Negativos"
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
-      - echo "Downloading repo & Installing gum"
+      - echo "Downloading charm repo"
       - echo -e '[charm]\nname=Charm\nbaseurl=https://repo.charm.sh/yum/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.charm.sh/yum/gpg.key' > /etc/yum.repos.d/charm.repo
+      - echo "Installing gum"
       - rpm-ostree install gum
       # Remove chsh
+      - echo "Removing chsh"
       - rm /usr/bin/chsh
-
+      # Install oversteer udev rules
+      - echo "Downloading Oversteer udev zip file"
+      - curl -fLs --create-dirs  https://github.com/berarma/oversteer/archive/refs/heads/master.zip -o /tmp/oversteer-udev/master.zip
+      - echo "Unzipping Oversteer udev zip file"
+      - unzip -q /tmp/oversteer-udev/master.zip -d /tmp/oversteer-udev/
+      - rm /tmp/oversteer-udev/master.zip
+      - echo "Copying Oversteer udev rules"
+      - cp /tmp/oversteer-udev/oversteer-master/data/udev/*.rules /usr/lib/udev/rules.d/
+      - rm -r /tmp/oversteer-udev/
+      
   - type: rpm-ostree
     remove:
       - fdk-aac-free
@@ -127,7 +138,6 @@ modules:
       # Some additional udev rules
       - openrgb-udev-rules
       - solaar-udev
-      - oversteer-udev
       # Yubikey stuff
       - pam-u2f
       - pam_yubico

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -128,6 +128,7 @@ modules:
       - libswscale-free
       - default-fonts-cjk-sans
       - google-noto-sans-cjk-vf-fonts
+      - gnome-software-rpm-ostree
     install:
       # Font stuff
       - google-noto-sans-balinese-fonts

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -8,56 +8,56 @@ modules:
   - type: script
     snippets:
       # Download Universal Blue config zip
-      - echo "Downloading Universal Blue config zip file"
+      - echo -e "\033[90mDownloading Universal Blue config zip file\033[0m"
       - curl -fLs --create-dirs https://github.com/ublue-os/config/archive/refs/heads/main.zip -o /tmp/ublue-config/main.zip
-      - echo "Unzipping the file"
+      - echo -e "\033[90mUnzipping the file\033[0m"
       - unzip -q /tmp/ublue-config/main.zip -d /tmp/ublue-config/
       - rm /tmp/ublue-config/main.zip
       # Universal Blue udev rules    
-      - echo "Copying udev rules from Universal Blue"
+      - echo -e "\033[90mCopying udev rules from Universal Blue\033[0m"
       - cp /tmp/ublue-config/config-main/files/etc/udev/rules.d/*.rules /usr/lib/udev/rules.d/
       # Game-device-udev rules
-      - echo "Downloading game-device-udev zip file"    
+      - echo -e "\033[90mDownloading game-device-udev zip file\033[0m"    
       - curl -fLs --create-dirs https://codeberg.org/fabiscafe/game-devices-udev/archive/main.zip -o /tmp/ublue-config/game-devices-udev/main.zip
-      - echo "Unzipping the file"
+      - echo -e "\033[90mUnzipping the file\033[0m"
       - unzip -q /tmp/ublue-config/game-devices-udev/main.zip -d /tmp/ublue-config/game-devices-udev/
       - rm /tmp/ublue-config/game-devices-udev/main.zip
-      - echo "Copying udev rules from Game-device-udev"
+      - echo -e "\033[90mCopying udev rules from Game-device-udev\033[0m"
       - cp /tmp/ublue-config/game-devices-udev/game-devices-udev/*.rules /usr/lib/udev/rules.d/
-      - echo "Putting uinput to be loaded as a module in modules-load.d"
+      - echo -e "\033[90mPutting uinput to be loaded as a module in modules-load.d\033[0m"
       - echo "uinput" > /usr/lib/modules-load.d/uinput.conf
       # Android udev rule
-      - echo "Downloading Android udev rule"
+      - echo -e "\033[90mDownloading Android udev rule\033[0m"
       - curl -fLs --create-dirs https://raw.githubusercontent.com/M0Rf30/android-udev-rules/refs/heads/main/51-android.rules -o /usr/lib/udev/rules.d/51-android.rules
-      - echo "Adding adbusers group to sysusers.d"
+      - echo -e "\033[90mAdding adbusers group to sysusers.d\033[0m"
       - echo "g adbusers - -" > /usr/lib/sysusers.d/android-udev.conf
       # rpm-ostree & flatpak updaters
       ## rpm-ostree updater
-      - echo "Copying rpm-ostree updater"
+      - echo -e "\033[90mCopying rpm-ostree updater\033[0m"
       - mkdir -p /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/ /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/
       - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.timer.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.timer.d/override.conf
       - cp /tmp/ublue-config/config-main/files/etc/systemd/system/rpm-ostreed-automatic.service.d/override.conf /usr/lib/systemd/system/rpm-ostreed-automatic.service.d/override.conf
-      - echo "Enabling rpm-ostree updates in config"
+      - echo -e "\033[90mEnabling rpm-ostree updates in config\033[0m"
       - sed -i 's/^AutomaticUpdatePolicy=.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf
       ## flatpak updater
-      - echo "Copying flatpak updater"
+      - echo -e "\033[90mCopying flatpak updater\033[0m"
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.timer /usr/lib/systemd/system/flatpak-system-update.timer
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/system/flatpak-system-update.service /usr/lib/systemd/system/flatpak-system-update.service
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/user/flatpak-user-update.timer /usr/lib/systemd/user/flatpak-user-update.timer
       - cp /tmp/ublue-config/config-main/files/usr/lib/systemd/user/flatpak-user-update.service /usr/lib/systemd/user/flatpak-user-update.service
-      - echo "Enabling systemd timers for flatpak updaters"
+      - echo -e "\033[90mEnabling systemd timers for flatpak updaters\033[0m"
       - systemctl --system enable flatpak-system-update.timer
       - systemctl --global enable flatpak-user-update.timer
       # Add just config from Universal Blue
-      - echo "Adding just config from Universal Blue"
-      - echo "Excluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)"
+      - echo -e "\033[90mAdding just config from Universal Blue\033[0m"
+      - echo -e "\033[90mExcluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)\033[0m"
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
       ## Include Gidro-OS justfile
-      - echo "Only including Gidro-OS justfile"
-      - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/just/justfile
+      - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
+      - echo -e "\033[90mimport /usr/share/ublue-os/just/60-custom.just\033[0m" >> /usr/share/ublue-os/just/justfile
       ## Copy ujust & ugum binary
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust; chmod -x /usr/bin/ujust
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum; chmod -x /usr/bin/ugum
@@ -65,7 +65,7 @@ modules:
       - mkdir -p /usr/lib/ujust/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/
       # Use ZSTD compression for initramfs
-      - echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
+      - echo -e "\033[90mcompress=\"zstd\"\033[0m" > /usr/lib/dracut/dracut.conf.d/10-compression.conf
       # Remove temporary directory
       - rm -r /tmp/ublue-config/ 
 
@@ -76,27 +76,27 @@ modules:
   - type: script
     snippets:
       # Install Negativo repo
-      - echo "Installing Negativo repo"
+      - echo -e "\033[90mInstalling Negativo repo\033[0m"
       - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -o /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       # Replace Fedora packages with Negativos (Mesa & HEIF)
-      - echo "Replacing Fedora packages with Negativos"
+      - echo -e "\033[90mReplacing Fedora packages with Negativos\033[0m"
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
-      - echo "Downloading charm repo"
+      - echo -e "\033[90mDownloading charm repo\033[0m"
       - echo -e '[charm]\nname=Charm\nbaseurl=https://repo.charm.sh/yum/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.charm.sh/yum/gpg.key' > /etc/yum.repos.d/charm.repo
-      - echo "Installing gum"
+      - echo -e "\033[90mInstalling gum\033[0m"
       - rpm-ostree install gum
       # Remove chsh
-      - echo "Removing chsh"
+      - echo -e "\033[90mRemoving chsh\033[0m"
       - rm /usr/bin/chsh
       # Install oversteer udev rules
-      - echo "Downloading Oversteer udev zip file"
+      - echo -e "\033[90mDownloading Oversteer udev zip file\033[0m"
       - curl -fLs --create-dirs  https://github.com/berarma/oversteer/archive/refs/heads/master.zip -o /tmp/oversteer-udev/master.zip
-      - echo "Unzipping Oversteer udev zip file"
+      - echo -e "\033[90mUnzipping Oversteer udev zip file\033[0m"
       - unzip -q /tmp/oversteer-udev/master.zip -d /tmp/oversteer-udev/
       - rm /tmp/oversteer-udev/master.zip
-      - echo "Copying Oversteer udev rules"
+      - echo -e "\033[90mCopying Oversteer udev rules\033[0m"
       - cp /tmp/oversteer-udev/oversteer-master/data/udev/*.rules /usr/lib/udev/rules.d/
       - rm -r /tmp/oversteer-udev/
       

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -88,8 +88,8 @@ modules:
       - DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"
       - curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
       # Remove chsh & lchsh
-      rm /usr/bin/chsh
-      rm /usr/bin/lchsh
+      - rm /usr/bin/chsh
+      - rm /usr/bin/lchsh
 
   - type: rpm-ostree
     remove:

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -16,6 +16,9 @@ modules:
       # Universal Blue udev rules    
       - echo -e "\033[90mCopying udev rules from Universal Blue\033[0m"
       - cp /tmp/ublue-config/config-main/files/etc/udev/rules.d/*.rules /usr/lib/udev/rules.d/
+      ## Add plugdev group to sysusers.d (needed for Yubikey udev rules)
+      - echo -e "\033[90mAdd plugdev group to sysuser.d (not done in Ublue)\033[0m"      
+      - echo "g plugdev -" > /usr/lib/sysusers.d/30-append-plugdev-group.conf
       # Game-device-udev rules
       - echo -e "\033[90mDownloading game-device-udev zip file\033[0m"    
       - curl -fLs --create-dirs https://codeberg.org/fabiscafe/game-devices-udev/archive/main.zip -o /tmp/ublue-config/game-devices-udev/main.zip
@@ -51,12 +54,18 @@ modules:
       # Add just config from Universal Blue
       - echo -e "\033[90mAdding just config from Universal Blue\033[0m"
       - echo -e "\033[90mExcluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)\033[0m"
-      # Copy profile.d just script
+      ## Copy profile.d just script
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
-      # Copy 60-custom.just template & ublue-os justfile template
+      ## Add function to invoke ujust when typing just
+      - echo -e "\033[90mAdd function to execute ujust when typing just (not done in Ublue)\033[0m"      
+      - echo -e "# Alias ujust to just, so using \`just\` command works\njust() {\n  if [ \${#} -eq 0 ]; then\n    /usr/bin/ujust\n  elif [ -n \"\${1}\" ] && [ ! \"\${1}\" = \"--choose\" ]; then\n    ujust_commands=\$(/usr/bin/just --justfile /usr/share/ublue-os/justfile --list | awk 'NR>1 {printf \"%s \", \$1} END {print \"\"}')\n    if echo \" \${ujust_commands} \" | grep -q \" \${1} \"; then\n      /usr/bin/ujust \"\${@}\"\n    else\n      /usr/bin/just \"\${@}\"\n    fi\n  else\n    /usr/bin/just \"\${@}\"\n  fi\n}\nexport -f just" >> /etc/profile.d/ublue-os-just.sh
+      ## Copy 60-custom.just template & ublue-os justfile template
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/justfile
+      ## Don't show link for Universal Blue documentation when invoking `ujust`
+      - echo -e "\033[90mDon't show link for Ublue docs when executing ujust (not done in Ublue)\033[0m"      
+      - sed -i '/^[[:space:]]*echo "\$(Urllink/d' /usr/share/ublue-os/justfile      
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
       - echo "import \"/usr/share/ublue-os/just/60-custom.just\"" >> /usr/share/ublue-os/justfile
@@ -83,6 +92,9 @@ modules:
       - echo -e "\033[90mInstalling Negativo repo\033[0m"
       - curl -fLs --create-dirs https://negativo17.org/repos/fedora-multimedia.repo -o /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+      # Remove redundant RPMFusion repos
+      - echo -e "\033[90mRemove redundant RPMFusion repos (not done in Ublue)\033[0m"
+      - rm /etc/yum.repos.d/rpmfusion-*.repo
       # Replace Fedora packages with Negativos (Mesa & HEIF)
       - echo -e "\033[90mReplacing Fedora packages with Negativos\033[0m"
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
@@ -98,6 +110,9 @@ modules:
       - echo -e "\033[90mCopying Oversteer udev rules\033[0m"
       - cp /tmp/oversteer-udev/oversteer-master/data/udev/*.rules /usr/lib/udev/rules.d/
       - rm -r /tmp/oversteer-udev/
+      # Remove avif thumbnailer, as HEIF thumbnailer already covers it
+      - echo -e "\033[90mRemove avif thumbnailer, as HEIF thumbnailer already covers it (not done in Ublue)\033[0m"      
+      - rm /usr/share/thumbnailers/avif.thumbnailer
       
   - type: rpm-ostree
     remove:
@@ -152,17 +167,3 @@ modules:
       - libratbag-ratbagd
       - zstd
       - wireguard-tools
-      
-  # My additions to the base image, which are not present in Ublue    
-  - type: script
-    snippets:
-      # Remove avif thumbnailer, as HEIF thumbnailer already covers it        
-      - rm /usr/share/thumbnailers/avif.thumbnailer
-      # Don't show link for Universal Blue documentation when invoking `ujust`
-      - sed -i '/^[[:space:]]*echo "\$(Urllink/d' /usr/share/ublue-os/justfile      
-      # Add function to invoke ujust when typing just
-      - echo -e "# Alias ujust to just, so using \`just\` command works\njust() {\n  if [ \${#} -eq 0 ]; then\n    /usr/bin/ujust\n  elif [ -n \"\${1}\" ] && [ ! \"\${1}\" = \"--choose\" ]; then\n    ujust_commands=\$(/usr/bin/just --justfile /usr/share/ublue-os/justfile --list | awk 'NR>1 {printf \"%s \", \$1} END {print \"\"}')\n    if echo \" \${ujust_commands} \" | grep -q \" \${1} \"; then\n      /usr/bin/ujust \"\${@}\"\n    else\n      /usr/bin/just \"\${@}\"\n    fi\n  else\n    /usr/bin/just \"\${@}\"\n  fi\n}\nexport -f just" >> /etc/profile.d/ublue-os-just.sh
-      # Add plugdev group to sysusers.d (needed for Yubikey udev rules)
-      - echo "g plugdev -" > /usr/lib/sysusers.d/30-append-plugdev-group.conf
-      # Remove redundant RPMFusion repos
-      - rm /etc/yum.repos.d/rpmfusion-*.repo

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -84,7 +84,7 @@ modules:
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
       - echo "Downloading & Installing gum"
-      - echo -e '#!/usr/bin/env bash\n\ncurl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r ".tag_name"\nDOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"\ncurl -fLs --create-dirs "${DOWNLOAD_URL}" -o /tmp/gum.rpm\nrpm-ostree install /tmp/gum.rpm' > /tmp/install-gum.sh
+      - echo -e '#!/usr/bin/env bash\n\ncurl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r ".tag_name"\nDOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"\nrpm-ostree install "${DOWNLOAD_URL}"' > /tmp/install-gum.sh
       - chmod +x /tmp/install-gum.sh
       - /tmp/install-gum.sh
       - rm /tmp/install-gum.sh

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -62,6 +62,7 @@ modules:
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust; chmod -x /usr/bin/ujust
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum; chmod -x /usr/bin/ugum
       ## Copy ujust libraries
+      - mkdir -p /usr/lib/ujust/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/
       # Use ZSTD compression for initramfs
       - echo "compress=\"zstd\"" > /usr/lib/dracut/dracut.conf.d/10-compression.conf

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -69,9 +69,10 @@ modules:
       # Remove temporary directory
       - rm -r /tmp/ublue-config/ 
 
+  # Covering ublue-os/main here
   # Add negativo repo, modify its repo priority & replace some packages like HEIF & mesa
   # Also install gum
-  # The operations above cannot be covered in rpm-ostree module, so it's used as a script
+  # The operations below cannot be covered in rpm-ostree module, so it's used as a script
   - type: script
     snippets:
       # Install Negativo repo
@@ -80,12 +81,15 @@ modules:
       - sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
       # Replace Fedora packages with Negativos (Mesa & HEIF)
       - echo "Replacing Fedora packages with Negativos"
-      - rpm-ostree override replace --experimental from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
+      - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
       - echo "Downloading & Installing gum"
       - LATEST_RELEASE=$(curl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r '.tag_name')
       - DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"
       - curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
+      # Remove chsh & lchsh
+      rm /usr/bin/chsh
+      rm /usr/bin/lchsh
 
   - type: rpm-ostree
     remove:

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -57,7 +57,7 @@ modules:
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/just/justfile
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
-      - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/just/justfile
+      - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/justfile
       ## Copy ujust & ugum binary
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust
       - chmod 755 /usr/bin/ujust

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -75,7 +75,7 @@ modules:
 
   # Covering ublue-os/main here
   # Add negativo repo, modify its repo priority & replace some packages like HEIF & mesa
-  # Also install gum
+  # Remove chsh & install oversteer-udev rules, as I don't want to rely on potentially outdated RPM
   # The operations below cannot be covered in rpm-ostree module, so it's used as a script
   - type: script
     snippets:

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -84,9 +84,7 @@ modules:
       - rpm-ostree override replace --experimental --from repo='fedora-multimedia' libheif libva libva-intel-media-driver mesa-dri-drivers mesa-filesystem mesa-libEGL mesa-libGL mesa-libgbm mesa-libglapi mesa-libxatracker mesa-va-drivers mesa-vulkan-drivers
       # Install gum
       - echo "Downloading & Installing gum"
-      - LATEST_RELEASE=$(curl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r '.tag_name')
-      - DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"
-      - curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
+      - LATEST_RELEASE=$(curl -s https://api.github.com/repos/charmbracelet/gum/releases/latest | jq -r '.tag_name'); DOWNLOAD_URL="https://github.com/charmbracelet/gum/releases/download/${LATEST_RELEASE}/gum-${LATEST_RELEASE}-1.x86_64.rpm"; curl -fLs --create-dirs ${DOWNLOAD_URL} -o /usr/bin/gum
       # Remove chsh & lchsh
       - rm /usr/bin/chsh
       - rm /usr/bin/lchsh

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -53,8 +53,6 @@ modules:
       - echo -e "\033[90mExcluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)\033[0m"
       # Copy profile.d just script
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
-      # Add function to invoke ujust when typing just
-      - echo -e "# Alias ujust to just, so using \`just\` command works\njust() {\n  if [ \${#} -eq 0 ]; then\n    /usr/bin/ujust\n  elif [ -n \"\${1}\" ] && [ ! \"\${1}\" = \"--choose\" ]; then\n    ujust_commands=\$(/usr/bin/just --justfile /usr/share/ublue-os/justfile --list | awk 'NR>1 {printf \"%s \", \$1} END {print \"\"}')\n    if echo \" \${ujust_commands} \" | grep -q \" \${1} \"; then\n      /usr/bin/ujust \"\${@}\"\n    else\n      /usr/bin/just \"\${@}\"\n    fi\n  else\n    /usr/bin/just \"\${@}\"\n  fi\n}\nexport -f just" >> /etc/profile.d/ublue-os-just.sh
       # Copy 60-custom.just template & ublue-os justfile template
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
@@ -160,8 +158,11 @@ modules:
       - libratbag-ratbagd
       - zstd
       - wireguard-tools
+      
   # My additions to the base image, which are not present in Ublue    
-  # Remove avif thumbnailer, as HEIF thumbnailer already covers it    
   - type: script
     snippets:
+      # Remove avif thumbnailer, as HEIF thumbnailer already covers it        
       - rm /usr/share/thumbnailers/avif.thumbnailer
+      # Add function to invoke ujust when typing just
+      - echo -e "# Alias ujust to just, so using \`just\` command works\njust() {\n  if [ \${#} -eq 0 ]; then\n    /usr/bin/ujust\n  elif [ -n \"\${1}\" ] && [ ! \"\${1}\" = \"--choose\" ]; then\n    ujust_commands=\$(/usr/bin/just --justfile /usr/share/ublue-os/justfile --list | awk 'NR>1 {printf \"%s \", \$1} END {print \"\"}')\n    if echo \" \${ujust_commands} \" | grep -q \" \${1} \"; then\n      /usr/bin/ujust \"\${@}\"\n    else\n      /usr/bin/just \"\${@}\"\n    fi\n  else\n    /usr/bin/just \"\${@}\"\n  fi\n}\nexport -f just" >> /etc/profile.d/ublue-os-just.sh

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -51,7 +51,11 @@ modules:
       # Add just config from Universal Blue
       - echo -e "\033[90mAdding just config from Universal Blue\033[0m"
       - echo -e "\033[90mExcluding motd tips, Ublue justfiles, distrobox+podman manifest files & brew profile.d script (not needed)\033[0m"
+      # Copy profile.d just script
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/etc-profile.d/ublue-os-just.sh /etc/profile.d/ublue-os-just.sh
+      # Add function to invoke ujust when typing just
+      - echo -e "# Alias ujust to just, so using \`just\` command works\njust() {\n  if [ \${#} -eq 0 ]; then\n    /usr/bin/ujust\n  elif [ -n \"\${1}\" ] && [ ! \"\${1}\" = \"--choose\" ]; then\n    ujust_commands=\$(/usr/bin/just --justfile /usr/share/ublue-os/justfile --list | awk 'NR>1 {printf \"%s \", \$1} END {print \"\"}')\n    if echo \" \${ujust_commands} \" | grep -q \" \${1} \"; then\n      /usr/bin/ujust \"\${@}\"\n    else\n      /usr/bin/just \"\${@}\"\n    fi\n  else\n    /usr/bin/just \"\${@}\"\n  fi\n}\nexport -f just" >> /etc/profile.d/ublue-os-just.sh
+      # Copy 60-custom.just template & ublue-os justfile template
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/justfile

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -164,3 +164,5 @@ modules:
       - echo -e "# Alias ujust to just, so using \`just\` command works\njust() {\n  if [ \${#} -eq 0 ]; then\n    /usr/bin/ujust\n  elif [ -n \"\${1}\" ] && [ ! \"\${1}\" = \"--choose\" ]; then\n    ujust_commands=\$(/usr/bin/just --justfile /usr/share/ublue-os/justfile --list | awk 'NR>1 {printf \"%s \", \$1} END {print \"\"}')\n    if echo \" \${ujust_commands} \" | grep -q \" \${1} \"; then\n      /usr/bin/ujust \"\${@}\"\n    else\n      /usr/bin/just \"\${@}\"\n    fi\n  else\n    /usr/bin/just \"\${@}\"\n  fi\n}\nexport -f just" >> /etc/profile.d/ublue-os-just.sh
       # Add plugdev group to sysusers.d (needed for Yubikey udev rules)
       - echo "g plugdev -" > /usr/lib/sysusers.d/30-append-plugdev-group.conf
+      # Remove redundant RPMFusion repos
+      - rm /etc/yum.repos.d/rpmfusion-*.repo

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -59,8 +59,10 @@ modules:
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
       - echo "import /usr/share/ublue-os/just/60-custom.just" >> /usr/share/ublue-os/just/justfile
       ## Copy ujust & ugum binary
-      - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust; chmod -x /usr/bin/ujust
-      - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum; chmod -x /usr/bin/ugum
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/ujust /usr/bin/ujust
+      - chmod 755 /usr/bin/ujust
+      - cp /tmp/ublue-config/config-main/build/ublue-os-just/ugum /usr/bin/ugum
+      - chmod 755 /usr/bin/ugum
       ## Copy ujust libraries
       - mkdir -p /usr/lib/ujust/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/lib-ujust/* /usr/lib/ujust/

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -57,8 +57,6 @@ modules:
       - mkdir -p /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/60-custom.just /usr/share/ublue-os/just/
       - cp /tmp/ublue-config/config-main/build/ublue-os-just/header.just /usr/share/ublue-os/justfile
-      ## Don't show link for Universal Blue documentation when invoking `ujust`
-      - sed -i '/^[[:space:]]*echo "\$(Urllink/d' /usr/share/ublue-os/justfile
       ## Include Gidro-OS justfile
       - echo -e "\033[90mOnly including Gidro-OS justfile\033[0m"
       - echo "import \"/usr/share/ublue-os/just/60-custom.just\"" >> /usr/share/ublue-os/justfile
@@ -164,5 +162,9 @@ modules:
     snippets:
       # Remove avif thumbnailer, as HEIF thumbnailer already covers it        
       - rm /usr/share/thumbnailers/avif.thumbnailer
+      # Don't show link for Universal Blue documentation when invoking `ujust`
+      - sed -i '/^[[:space:]]*echo "\$(Urllink/d' /usr/share/ublue-os/justfile      
       # Add function to invoke ujust when typing just
       - echo -e "# Alias ujust to just, so using \`just\` command works\njust() {\n  if [ \${#} -eq 0 ]; then\n    /usr/bin/ujust\n  elif [ -n \"\${1}\" ] && [ ! \"\${1}\" = \"--choose\" ]; then\n    ujust_commands=\$(/usr/bin/just --justfile /usr/share/ublue-os/justfile --list | awk 'NR>1 {printf \"%s \", \$1} END {print \"\"}')\n    if echo \" \${ujust_commands} \" | grep -q \" \${1} \"; then\n      /usr/bin/ujust \"\${@}\"\n    else\n      /usr/bin/just \"\${@}\"\n    fi\n  else\n    /usr/bin/just \"\${@}\"\n  fi\n}\nexport -f just" >> /etc/profile.d/ublue-os-just.sh
+      # Add plugdev group to sysusers.d (needed for Yubikey udev rules)
+      - echo "g plugdev -" > /usr/lib/sysusers.d/30-append-plugdev-group.conf

--- a/recipes/module-recipes/akmods.yml
+++ b/recipes/module-recipes/akmods.yml
@@ -1,8 +1,0 @@
-type: akmods
-install:
-  - nct6687d
-  - openrazer
-  - v4l2loopback
-  - xone    
-  - xpadneo
-  - zenergy

--- a/recipes/module-recipes/rpm-ostree.yml
+++ b/recipes/module-recipes/rpm-ostree.yml
@@ -39,4 +39,3 @@ remove:
   - gnome-shell-extension-places-menu
   - gnome-shell-extension-window-list
   - gnome-classic-session
-  - gnome-tweaks

--- a/recipes/module-recipes/rpm-ostree.yml
+++ b/recipes/module-recipes/rpm-ostree.yml
@@ -24,15 +24,12 @@ install:
   - rar
   - pandoc
   - power-profiles-daemon
-  - totem-video-thumbnailer
 
 remove:
   - tuned
   - tuned-ppd
   - firefox
   - firefox-langpacks
-  - htop
-  - nvtop
   - gnome-tour
   - gnome-initial-setup
   - gnome-system-monitor

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -6,4 +6,3 @@ scripts:
   - morewaita.sh
   - initramfs.sh
   - sleep-through-notifications.sh
-  - remove-redundant-avif-thumbnailer.sh

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -5,7 +5,7 @@ description: My personalized custom OS image.
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: quay.io/fedora-ostree-desktops/silverblue
-image-version: latest # latest is also supported if you want new updates ASAP
+image-version: 41 # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order
 # you can include multiple instances of the same module

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -4,14 +4,14 @@ name: gidro-os
 description: My personalized custom OS image.
 
 # the base image to build on top of (FROM) and the version tag to use
-base-image: ghcr.io/ublue-os/silverblue-main
+base-image: quay.io/fedora-ostree-desktops/silverblue
 image-version: latest # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order
 # you can include multiple instances of the same module
 modules:
+  - from-file: base.yml
   - from-file: module-recipes/files.yml
-  - from-file: module-recipes/akmods.yml 
   - from-file: module-recipes/rpm-ostree.yml
   - from-file: module-recipes/gnome-extensions.yml
   - from-file: module-recipes/justfiles.yml


### PR DESCRIPTION
# Reason

- **More control**
- **Immediate reaction to changes if/when needed**
- **Removing unnecessary & potentionally clashing packages + config from Universal Blue**
- **Reducing image-size (& update time with it)**
- **Ditching the need to enroll key for Secure Boot (especially during UEFI updates)**
- **Having easier & more enjoyable BlueBuild workflow**

# Changes
- **Removed akmods support**
   - Those would need to be signed with my own key, which is something I wouldn't like to do. Also, I didn't have need for akmods at all, but kept them as hardware enablement, just in case
- **Stripped some unecessary packages & config from Universal Blue**
    -  Only Gidro-OS just scripts are included now, as I want to avoid the potential foot-gun of some user running sub-par Universal Blue just script
    - Removed some packages related to debugging (other tools can still be used) & some opinionated unecessary stuff (like apr, flatpak-spawn & similar)

# To-do
- **Remove Gnome Software epiphany-runtime & dkms(akmods)-helper**
  - Harder to do, since it would take to fork RPM spec, which I wouldn't like to do