### PR TITLE
chore: Merge needed changes for Fedora 42

### DIFF
--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -86,7 +86,6 @@ modules:
         - repo: fedora-multimedia
           packages:
             - libheif
-            - mesa-libxatracker
     replace:
       - from-repo: fedora-multimedia
         packages:

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -190,3 +190,5 @@ modules:
     snippets:
       # Workaround non-working Chinese, Japanese & Korean fonts
       - ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
+      # Rename chinese just README to not contain UTF-8, due to a bug with ISO installer
+      - mv "/usr/share/doc/just/README.中文.md" "/usr/share/doc/just/README.zh-cn.md"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -16,3 +16,5 @@ snippets:
   # Patch Media Progress Gnome extension to use system Nokia Pure Text T font instead of the hardcoded one
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
+  # Remove non-ASCII README file for just, as it causes issue with ostree in installation ISO
+- "find /usr/share/doc/just -type f ! -name '*[! -~]*' -exec sh -c 'echo "Removing: $1"; rm "$1"' _ {} \;"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -17,4 +17,4 @@ snippets:
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
   # Remove non-ASCII files or directories in /usr, as it causes issues with the installation ISO
-- "find /usr -name '*[![:ascii:]]*' -print0 | xargs -0 rm -rf"
+  - "find /usr -name '*[![:ascii:]]*' -print0 | xargs -0 rm -rf"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -16,5 +16,3 @@ snippets:
   # Patch Media Progress Gnome extension to use system Nokia Pure Text T font instead of the hardcoded one
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
-  # Remove non-ASCII README file for just package, as it causes issues with the installation ISO
-  - "rm /usr/share/doc/just/README.中文.md"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -17,4 +17,4 @@ snippets:
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
   # Remove non-ASCII files or directories in /usr, as it causes issues with the installation ISO
-  - "find /usr -name '*[![:ascii:]]*' -print0 | xargs -0 rm -rf"
+  - "find /usr -print0 | perl -MFile::Path=remove_tree -n0e 'chomp; remove_tree($_, {verbose=>1}) if /[[:^ascii:][:cntrl:]]/'"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -16,5 +16,5 @@ snippets:
   # Patch Media Progress Gnome extension to use system Nokia Pure Text T font instead of the hardcoded one
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
-  # Remove non-ASCII files or directories in /usr, as it causes issues with the installation ISO
-  - "find /usr -print0 | perl -MFile::Path=remove_tree -n0e 'chomp; remove_tree($_, {verbose=>1}) if /[[:^ascii:][:cntrl:]]/'"
+  # Remove non-ASCII README file for just package, as it causes issues with the installation ISO
+  - "rm /usr/share/doc/just/README.中文.md"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -17,4 +17,4 @@ snippets:
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
   # Remove non-ASCII README file for just, as it causes issue with ostree in installation ISO
-- find /usr/share/doc/just -type f ! -name '*[! -~]*' -exec sh -c 'echo "Removing: $1"; rm "$1"' _ {} \;
+- "find /usr/share/doc/just -type f ! -name '*[! -~]*' -exec sh -c 'echo \"Removing: \$1\"; rm \"\$1\"' _ {} \\;"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -16,5 +16,5 @@ snippets:
   # Patch Media Progress Gnome extension to use system Nokia Pure Text T font instead of the hardcoded one
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
-  # Remove non-ASCII README file for just, as it causes issue with ostree in installation ISO
-- "find /usr/share/doc/just -type f ! -name '*[! -~]*' -exec sh -c 'echo \"Removing: \$1\"; rm \"\$1\"' _ {} \\;"
+  # Remove non-ASCII files or directories in /usr, as it causes issues with the installation ISO
+- "find /usr -name '*[![:ascii:]]*' -print0 | xargs -0 rm -rf"

--- a/recipes/module-recipes/scripts.yml
+++ b/recipes/module-recipes/scripts.yml
@@ -17,4 +17,4 @@ snippets:
   # Using tabular version of the font because it's more suitable for the numbers, as that's what extension is showing
   - "sed -i 's/font-family: [^;]*;/font-family: Nokia Pure Text T;/' /usr/share/gnome-shell/extensions/media-progress@krypion17/stylesheet.css"
   # Remove non-ASCII README file for just, as it causes issue with ostree in installation ISO
-- "find /usr/share/doc/just -type f ! -name '*[! -~]*' -exec sh -c 'echo "Removing: $1"; rm "$1"' _ {} \;"
+- find /usr/share/doc/just -type f ! -name '*[! -~]*' -exec sh -c 'echo "Removing: $1"; rm "$1"' _ {} \;

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -5,7 +5,7 @@ description: My personalized custom OS image.
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: quay.io/fedora-ostree-desktops/silverblue
-image-version: 42 # latest is also supported if you want new updates ASAP
+image-version: 41 # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order
 # you can include multiple instances of the same module


### PR DESCRIPTION
# Additional Changes

No additional changes.

# Maintaining Changes

- 4 extensions are not officially compatible with Gnome 48, and those are:
  - Gnome 4x UI Improvements
  - Media Progress
  - OpenWeather Refined
  - Sleep Through Notifications

Modifying `metadata.json` works for all of those, except Media Progress extension.

Sleep Through Notifications will likely need this workaround, since it's not active in maintenance, while I will wait for others to gain Gnome 48 support.

- Additional testing is needed to see if some other changes are necessary.