### PR TITLE
chore: Merge needed changes for Fedora 44

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         image_name: [gidro-os]
-        major_version: [43]
+        major_version: [44]
         image_tag: [latest]
 
     steps:
@@ -55,7 +55,7 @@ jobs:
           image_repo: ${{ env.IMAGE_REGISTRY }}
           image_name: ${{ matrix.image_name }}
           image_tag: ${{ matrix.image_tag }}
-          variant: 'Kinoite'
+          variant: 'Server'
           iso_name: ${{ matrix.image_name }}_${{ env.TIMESTAMP }}.iso
           enable_cache_dnf: "false"
           enable_cache_skopeo: "false"

--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ Settings applied by default:
 - [Disabled option for installing system packages, aka layering through `rpm-ostree` & `dnf`](https://github.com/fiftydinar/gidro-os/wiki/2.-Unsupported-Operations#why-rpm-ostree-installremove-or-dnf-installremove-doesnt-work-to-installremove-some-applications-) (to ensure that system integrity & reliability remains untouched)
 - Prefer `bootc` for updating the system
   - Applied fix to update it without invoking `sudo`
-- [Enabled experimental support for Variable Refresh Rate on supported screens](https://global.samsungdisplay.com/31137) (improves video & gaming experience by dynamically matching screen refresh rate with the content framerate)
-- [Enabled Vulkan support for AMD GCN 1.0 & GCN 2.0 GPUs](https://thespecter.net/blog/technology/enabling-amdgpu-on-fedora-31-for-using-vulkan-with-r7-and-r9-radeon-cards/) (for better performance & compatibility with those GPUs)
 - [Kyber I/O scheduler for SSDs/NVMEs, BFQ I/O scheduler for HDDs/microSDs/eMMCs](https://github.com/pop-os/default-settings/pull/149) (for improved responsiveness under I/O load)
 - [ZSTD I/O scheduler for ZRAM & better ZRAM values suited for desktop](https://github.com/pop-os/default-settings/pull/163) (avoids OOM situations better & it also improves responsiveness under I/O load. Also thanks to [MaxPerfWiz](https://gitlab.com/cscs/maxperfwiz) & [@ahydronous](https://gist.github.com/ahydronous/7ceaa00df96ef99131600edd4c2c73f2) for some good research & values.)
 - [Set memlock limit from 64kb to 2GB](https://github.com/RPCS3/rpcs3/issues/9328#issuecomment-732712084) (maps maximum locked value of 2GB per operation, needed for RPCS3 emulator)
@@ -142,7 +140,6 @@ Settings applied by default:
 - Power button powers off PC instead of suspending it
 - Enabled "Remove Old Trash files automatically" in Nautilus (every 30 days by default in Gnome)
 - Set mouse acceleration to flat
-- Disabled mouse middle-click to paste & touchpad 3-click to paste for GTK applications
 - Set Blur my Shell blur radius value to 8, as default value is too strong & looks cheap when using default background
 - Set SimpleWeather to do these things by default:
   - show sunrise/sunset in top bar
@@ -163,7 +160,6 @@ Settings applied by default:
 - Set Gnome Software to use Flathub-user remote by default (makes separation between OS flatpaks & user flatpaks much better)
 - Disable Gnome Software flatpak auto-updater (not needed since Gidro-OS uses included [ublue-os flatpak auto-updater](https://github.com/ublue-os/config/blob/main/rpmspec/ublue-os-update-services.spec))
 - Disable Gnome Software "Software Repositories" option (Warehouse implements the same functionality)
-- Use F41 version of Gnome Software until [annoying notification pop-up is fixed](https://gitlab.gnome.org/GNOME/gnome-software/-/issues/2802)
 - [Lock some settings to prevent users messing with the system reliability, while still remaining customizable](https://github.com/fiftydinar/gidro-os/wiki/2.-Unsupported-Operations#why-are-some-setting-toggles-grayed-out-i-cant-change-them)
 - Hide ROM Properties desktop shortcut
 - Enable silent auto-start on boot for those applications:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Settings applied by default:
 - Set Nautilus to show transparent thumbnails without checker patterns
 - Set keyboard delay to be much lower, as Gnome defaults are too slow
 - ["Window not responding" dialog extended to 20s](https://github.com/ValveSoftware/csgo-osx-linux/issues/669) (to prevent constant dialog showup in some games)
+- Always show log-out button (reverts nonsense change from Gnome 50)
 - Add Nautilus "New Document" to context menu
 - Set Gnome Software to use Flathub-user remote by default (makes separation between OS flatpaks & user flatpaks much better)
 - Disable Gnome Software flatpak auto-updater (not needed since Gidro-OS uses included [ublue-os flatpak auto-updater](https://github.com/ublue-os/config/blob/main/rpmspec/ublue-os-update-services.spec))

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Installed extensions:Update gnome-extensions.yml
 - [Bluetooth Battery Meter](https://maniacx.github.io/Bluetooth-Battery-Meter/)
 - [Night Theme Switcher](https://gitlab.com/rmnvgr/nightthemeswitcher-gnome-shell-extension)
 - [RebootToUEFI](https://github.com/UbayGD/reboottouefi)
-- [Gnome 4x UI Improvements](https://github.com/axxapy/gnome-ui-tune)
 - [Media Progress](https://github.com/Krypion17/media-progress)
 - [Quick Settings Audio Devices Renamer](https://extensions.gnome.org/extension/6000/quick-settings-audio-devices-renamer/) (disabled by default)
 - [Quick Settings Audio Devices Hider](https://extensions.gnome.org/extension/5964/quick-settings-audio-devices-hider/) (disabled by default)
@@ -150,7 +149,6 @@ Settings applied by default:
   - Show battery for upower 2.4Ghz devices
   - Enable experimental Bluetooth features to make it more compatible with it
 - Set Night Time Switcher time offset to 0 & set manual time (time based on automatic location is not accurate. Manual location can be specified instead)
-- Set Gnome 4x UI Improvements to only enable wallpaper thumbnails in workspace switcher
 - Set Media Progress to use Nokia Pure Text T font instead of the hardcoded one
 - Enabled Nautilus "Sort folders before files"
 - Set Nautilus to show transparent thumbnails without checker patterns

--- a/files/gschema-overrides/zz1-gidro.gschema.override
+++ b/files/gschema-overrides/zz1-gidro.gschema.override
@@ -18,7 +18,6 @@ document-font-name='Nokia Pure Text 11'
 font-hinting='none'
 font-rendering='manual'
 font-name='Nokia Pure Text 11'
-gtk-enable-primary-paste=false
 gtk-theme='adw-gtk3'
 icon-theme='MoreWaita'
 monospace-font-name='Source Code Pro 10'
@@ -105,7 +104,7 @@ region='sr_RS.UTF-8@latin'
 
 [org.gnome.mutter:GNOME]
 check-alive-timeout=uint32 20000
-experimental-features=['variable-refresh-rate', 'scale-monitor-framebuffer', 'xwayland-native-scaling']
+experimental-features=['xwayland-native-scaling']
 
 [org.gnome.login-screen]
 logo='/usr/share/pixmaps/gidro-gdm-logo.png'

--- a/files/gschema-overrides/zz1-gidro.gschema.override
+++ b/files/gschema-overrides/zz1-gidro.gschema.override
@@ -39,7 +39,7 @@ titlebar-font='Nokia Pure Text Bold 11'
 power-button-action='interactive'
 
 [org.gnome.shell]
-enabled-extensions=['simple-weather@romanlefler.com', 'caffeine@patapon.info', 'blur-my-shell@aunetx', 'middleclickclose@paolo.tranquilli.gmail.com', 'notifications-alert-on-user-menu@hackedbellini.gmail.com', 'Bluetooth-Battery-Meter@maniacx.github.com', 'nightthemeswitcher@romainvigier.fr', 'reboottouefi@ubaygd.com', 'gnome-ui-tune@itstime.tech', 'media-progress@krypion17', 'appindicatorsupport@rgcjonas.gmail.com']
+enabled-extensions=['simple-weather@romanlefler.com', 'caffeine@patapon.info', 'blur-my-shell@aunetx', 'middleclickclose@paolo.tranquilli.gmail.com', 'notifications-alert-on-user-menu@hackedbellini.gmail.com', 'Bluetooth-Battery-Meter@maniacx.github.com', 'nightthemeswitcher@romainvigier.fr', 'reboottouefi@ubaygd.com', 'media-progress@krypion17', 'appindicatorsupport@rgcjonas.gmail.com']
 favorite-apps=['trivalent.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop']
 always-show-log-out=true
 
@@ -86,12 +86,6 @@ enable-upower-level-icon=true
 [org.gnome.shell.extensions.nightthemeswitcher.time]
 offset=0
 manual-schedule=true
-
-[org.gnome.shell.extensions.gnome-ui-tune]
-increase-thumbnails-size='100%'
-hide-search=false
-always-show-thumbnails=false
-overview-firefox-pip=false
 
 [org.gnome.software]
 allow-updates=false

--- a/files/gschema-overrides/zz1-gidro.gschema.override
+++ b/files/gschema-overrides/zz1-gidro.gschema.override
@@ -41,6 +41,7 @@ power-button-action='interactive'
 [org.gnome.shell]
 enabled-extensions=['simple-weather@romanlefler.com', 'caffeine@patapon.info', 'blur-my-shell@aunetx', 'middleclickclose@paolo.tranquilli.gmail.com', 'notifications-alert-on-user-menu@hackedbellini.gmail.com', 'Bluetooth-Battery-Meter@maniacx.github.com', 'nightthemeswitcher@romainvigier.fr', 'reboottouefi@ubaygd.com', 'gnome-ui-tune@itstime.tech', 'media-progress@krypion17', 'appindicatorsupport@rgcjonas.gmail.com']
 favorite-apps=['trivalent.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop']
+always-show-log-out=true
 
 [org.gnome.shell.extensions.blur-my-shell]
 pipelines={'pipeline_default': {'name': <'Default'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000000'>, 'params': <{'radius': <8>, 'brightness': <0.59999999999999998>, 'unscaled_radius': <8>}>}>]>}, 'pipeline_default_rounded': {'name': <'Default rounded'>, 'effects': <[<{'type': <'native_static_gaussian_blur'>, 'id': <'effect_000000000001'>, 'params': <{'radius': <30>, 'brightness': <0.59999999999999998>}>}>, <{'type': <'corner'>, 'id': <'effect_000000000002'>, 'params': <{'radius': <24>}>}>]>}}

--- a/recipes/base.yml
+++ b/recipes/base.yml
@@ -168,7 +168,6 @@ modules:
         #- adw-gtk3-theme
         - gvfs-nfs
         # Regular packages    
-        - openssl
         - libratbag-ratbagd
         - zstd
         - wireguard-tools

--- a/recipes/module-recipes/gnome-extensions.yml
+++ b/recipes/module-recipes/gnome-extensions.yml
@@ -9,7 +9,6 @@ modules:
       - Bluetooth Battery Meter
       - Night Theme Switcher
       - RebootToUEFI
-      #- Gnome 4x UI Improvements
       #- Media Progress
       - Quick Settings Audio Devices Renamer
       - Quick Settings Audio Devices Hider

--- a/recipes/module-recipes/gnome-extensions.yml
+++ b/recipes/module-recipes/gnome-extensions.yml
@@ -9,9 +9,14 @@ modules:
       - Bluetooth Battery Meter
       - Night Theme Switcher
       - RebootToUEFI
-      - Gnome 4x UI Improvements
-      - Media Progress
+      #- Gnome 4x UI Improvements
+      #- Media Progress
       - Quick Settings Audio Devices Renamer
       - Quick Settings Audio Devices Hider
       - Unblank lock screen
+      #- Notifications Alert
+  - type: gnome-extensions-unverified
+    source: local
+    install:
+      - Media Progress
       - Notifications Alert

--- a/recipes/module-recipes/gnome-extensions.yml
+++ b/recipes/module-recipes/gnome-extensions.yml
@@ -13,9 +13,8 @@ modules:
       - Quick Settings Audio Devices Renamer
       - Quick Settings Audio Devices Hider
       - Unblank lock screen
-      #- Notifications Alert
+      - Notifications Alert
   - type: gnome-extensions-unverified
     source: local
     install:
       - Media Progress
-      - Notifications Alert

--- a/recipes/module-recipes/kargs.yml
+++ b/recipes/module-recipes/kargs.yml
@@ -2,10 +2,5 @@ type: kargs
 kargs:
   # Enable full kernel preemption
   - preempt=full
-  # Use Vulkan driver for AMD GCN 1.0 & GCN 2.0 GPUs (HD 7000-8000 series)
-  - radeon.si_support=0
-  - radeon.cik_support=0
-  - amdgpu.si_support=1
-  - amdgpu.cik_support=1
   # Enable Nvidia GSP firmware for Nouveau driver
   - nouveau.config=NvGspRm=1

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -5,7 +5,7 @@ description: My personalized custom OS image.
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: quay.io/fedora-ostree-desktops/silverblue
-image-version: 43 # latest is also supported if you want new updates ASAP
+image-version: 44 # latest is also supported if you want new updates ASAP
 
 modules:
   - from-file: base.yml


### PR DESCRIPTION
# Gidro-OS changes

## Done

### Removal
- Gnome 4x UI Improvements extension is removed, as it's not available for Gnome 50 and `metadata.json` change is not enough. It has some useful options for a bit better aesthetic and usability, but it's not a crucial extension for Gidro-OS, hence why it's removed.
However, if it regains support for Gnome 50, I will revive it to be like before.

Edit: 2 days later after this merge, Gnome 4x UI Improvements is added later here with Gnome 50 patch:
https://github.com/fiftydinar/gidro-os/commit/4f3a885f183338952ee82b0b75eaa19ab518e057

### Maintenance (keeping up with the same state as before)
- Always show log-out option like before, reverting the Gnome 50 default
- Media Progress extension is installed as unverified, it works with simple `metadata.json` change
- No more need to disable mouse middle-click paste, as it's disabled in Gnome 50 by default
- No more need to set Variable Refresh Rate as experimental, as it's native by default in Gnome 50
- Same also goes for `scale-monitor-framebuffer`
- No more need to set kernel arguments for using amdgpu driver with Vulkan support on AMD GCN 1.0 & 2.0 GPUs (it's set by default since kernel 6.19)
- `openssl` is built into the base image now

# Fedora and Gnome changes

See:
- https://fedoraproject.org/wiki/Releases/44/ChangeSet
- https://release.gnome.org/50/
- https://medium.com/@emilyharbord2/gnome-50-features-and-setup-guide-d97473a3efec